### PR TITLE
Small tweak to prevent comment style override in some strings

### DIFF
--- a/hijs.js
+++ b/hijs.js
@@ -18,13 +18,13 @@ var keywords = ('var function if else for while break switch case do new null in
 // around the matched block of code.
 var syntax = [
   ['comment', /(\/\*(?:[^*\n]|\*+[^\/*])*\*+\/)/g],
-  ['comment', /(\/\/[^\n]*)/g],
   ['string' , /("(?:(?!")[^\\\n]|\\.)*"|'(?:(?!')[^\\\n]|\\.)*')/g],
   ['regexp' , /(\/.+\/[mgi]*)(?!\s*\w)/g],
   ['class'  , /\b([A-Z][a-zA-Z]+)\b/g],
   ['number' , /\b([0-9]+(?:\.[0-9]+)?)\b/g],
   ['keyword', new(RegExp)('\\b(' + keywords.join('|') + ')\\b', 'g')],
-  ['special', new(RegExp)('\\b(' + special.join('|') + ')\\b', 'g')]
+  ['special', new(RegExp)('\\b(' + special.join('|') + ')\\b', 'g')],
+  ['comment', /(\/\/[^\n]*)/g]
 ];
 var nodes, table = {};
 


### PR DESCRIPTION
Moved // comment processing at the end so as not to conflict with strings that may contain URLs, otherwise the // in the URL are treated like the start of a comment.
