### PR TITLE
Syntax highlighter doesn't work for jquery-like syntax...

### DIFF
--- a/hijs.js
+++ b/hijs.js
@@ -46,7 +46,7 @@ for (var i = 0, children; i < nodes.length; i++) {
 
         if (code.length >= 0) { // It's a text node
             // Don't highlight command-line snippets
-            if (! /^\$/.test(code.nodeValue.trim())) {
+            if (! /^\$\s/.test(code.nodeValue.trim())) {
                 syntax.forEach(function (s) {
                     var k = s[0], v = s[1];
                     code.nodeValue = code.nodeValue.replace(v, function (_, m) {

--- a/hijs.js
+++ b/hijs.js
@@ -17,9 +17,9 @@ var keywords = ('var function if else for while break switch case do new null in
 // The key becomes the class name of the <span>
 // around the matched block of code.
 var syntax = [
+  ['string' , /("(?:(?!")[^\\\n]|\\.)*"|'(?:(?!')[^\\\n]|\\.)*')/g],
   ['comment', /(\/\*(?:[^*\n]|\*+[^\/*])*\*+\/)/g],
   ['comment', /(\/\/[^\n]*)/g],
-  ['string' , /("(?:(?!")[^\\\n]|\\.)*"|'(?:(?!')[^\\\n]|\\.)*')/g],
   ['regexp' , /(\/.+\/[mgi]*)(?!\s*\w)/g],
   ['class'  , /\b([A-Z][a-zA-Z]+)\b/g],
   ['number' , /\b([0-9]+(?:\.[0-9]+)?)\b/g],


### PR DESCRIPTION
The classic jquery example (below) fails because it starts with $. So I'm proposing adding a check for whitespace after the $ to determine if it's a command line snippet.

<code>$("p.neat").addClass("ohmy").show("slow");</code>
